### PR TITLE
Prevent booleans causing exceptions when cleaning txdata

### DIFF
--- a/src/factui/api.cljc
+++ b/src/factui/api.cljc
@@ -235,6 +235,6 @@
   (w/prewalk (fn [n]
                (cond
                  (map? n) (into {} (filter (fn [[_ v]] (not (nil? v))) n))
-                 (coll? n) (filterv identity n)
+                 (coll? n) (filterv some? n)
                  :else n))
     txdata))

--- a/test/factui/api_test.cljc
+++ b/test/factui/api_test.cljc
@@ -271,12 +271,14 @@
 (deftest clean-tx-test
   (let [in [nil {:foo/bar 42
                  :foo/baz nil
+                 :foo/qux false
                  :foo/nib [nil 42]
                  :foo/nub #{nil 42}
                  :foo/nest {:biz/buz 42
                             :biz/boz nil}}
             nil]
         out [{:foo/bar 42
+              :foo/qux false
               :foo/nib [42]
               :foo/nub [42]
               :foo/nest {:biz/buz 42}}]]


### PR DESCRIPTION
Using `identity` when pruning nils from transaction data in the `clean-tx` helper function would cause boolean values to be removed from the [k v] pair, which would cause an exception when `conj`ing the pair back into the map.

This change includes a fix (by using `some?` rather than `identity`), and augments the `clean-tx` test to prevent regression.