### PR TITLE
readme fix on reactive queries example src code

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ For example, this code creates a listener on your primary app state atom, for th
 
 ```clojure
 (let [results-ch (chan)]
-    (swap! f/register app-state tasks-for-list [42] results-ch)
+    (swap! app-state f/register  tasks-for-list [42] results-ch)
     (go-loop []
         (when-let [results (<! results-ch)]
             (println "Got new results:" results))))


### PR DESCRIPTION
fixed the order of the args passed to example code for reactive queries in the readme.

```clojure
(let [results-ch (chan)]
    (swap! app-state f/register  tasks-for-list [42] results-ch)
    (go-loop []
        (when-let [results (<! results-ch)]
            (println "Got new results:" results))))
```