### PR TITLE
Entity retraction and ref types

### DIFF
--- a/src/factui/impl/store.cljc
+++ b/src/factui/impl/store.cljc
@@ -215,7 +215,7 @@
 
 (defn- resolve-tempids
   "Given a set of operations (which may contain temporary IDs), return a tuple
-   of concrete operatio (with tempids swapped for concrete EIDs) and the Tempid
+   of concrete operations (with tempids swapped for concrete EIDs) and the Tempid
    bindings.
 
    Note: only replaces tempids in :db/add operations."

--- a/test/factui/impl/session_test.cljc
+++ b/test/factui/impl/session_test.cljc
@@ -297,16 +297,33 @@
   (let [[s1 bindings] (api/transact base [{:db/id -42
                                            :person/id 42
                                            :person/name "Luke"
-                                           :person/likes ["Cheese" "Beer"]}])
+                                           :person/likes ["Cheese" "Beer"]}
+                                          {:db/id -20
+                                           :person/id 20
+                                           :person/name "Eugene"
+                                           :person/friends -42}])
+        ;; entitity we retract
         eid (bindings -42)
-        r1 (api/query s1 all-attrs eid)]
+        r1 (api/query s1 all-attrs eid)
+        ;; entity we retain
+        fid (bindings -20)
+        fr1 (api/query s1 all-attrs fid)]
+
     (is (= r1 #{[eid :person/id 42]
                 [eid :person/name "Luke"]
                 [eid :person/likes "Cheese"]
                 [eid :person/likes "Beer"]}))
+
+    (is (= fr1 #{[fid :person/id 20]
+                 [fid :person/name "Eugene"]
+                 [fid :person/friends eid]}))
+
     (let [s2 (api/transact-all s1 [[:db.fn/retractEntity eid]])
-          r2 (api/query s2 all-attrs eid)]
-      (is (empty? r2)))))
+          r2 (api/query s2 all-attrs eid)
+          fr2 (api/query s2 all-attrs fid)]
+      (is (empty? r2))
+      (is (= fr2 #{[fid :person/id 20]
+                   [fid :person/name "Eugene"]})))))
 
 (deftest retract-attrs
   (let [[s1 bindings] (api/transact base [{:db/id -42


### PR DESCRIPTION
# Premise
Entity retraction (via `:db.fn/retractEntity`) does not currently retract datoms in which the retracted entity comprises the `:v` component. 

# Approach

## VAE index 
Add a new field to the `SimpleStore` record representing the VAE index. Update the VAE index when facts are asserted/retracted. Consult the VAE index to build operations necessary to retract an entity.

# Appendix

## Basis
As per the [Datomic docs for `:db.fn/retractEntity`](https://docs.datomic.com/on-prem/transactions.html#dbfn-retractentity):
> The `:db.fn/retractEntity` function takes an entity id as an argument. It retracts all the attribute values where the given id is either the entity or value, effectively retracting the entity's own data **and any references to the entity as well**. Entities that are components of the given entity are also recursively retracted. 
 