### PR TITLE
Migrate the project to tools.deps in order to ease installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 *.log
 .idea
 *.iml
+.cpcache/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ In broad strokes:
 
 Query notification on updated facts is provided by the [RETE algorithm](https://en.wikipedia.org/wiki/Rete_algorithm), which is designed specifically to provide efficient activiation of rules in response to new facts. FactUI uses [Clara](http://www.clara-rules.org), an excellent RETE implementation for ClojureScript.
 
+## Installation
+
+Add the following to your `deps.edn`:
+
+```
+cjsauer/factui {:git/url "https://github.com/cjsauer/factui.git"
+                :sha     "9222bdd2778c5413792d067b81f3506935e2cdaa"}
+```
+
 ## Usage
 
 Note: This section provides documentation using FactUI's integration with the [Rum](https://github.com/tonsky/rum) React wrapper. FactUI is not tightly coupled with Rum, it is entirely possible to build integration between FactUI and alternative wrappers (such as [Reagent](https://reagent-project.github.io) or [Om](https://github.com/omcljs/om) with relatively little effort. However, those have not yet been built.

--- a/deps.edn
+++ b/deps.edn
@@ -6,15 +6,11 @@
         org.clojure/core.match {:mvn/version "0.3.0-alpha4"}}
 
  :aliases
- {:clj    {:extra-deps {;; Acts like "provided" :scope from lein
-                        org.clojure/clojure       {:mvn/version "1.10.0"}
-                        org.clojure/clojurescript {:mvn/version "1.9.671"}}}
-  :test   {:extra-paths ["test"]
-           :extra-deps  {org.clojure/test.check {:mvn/version "RELEASE"}}}
-  :runner {:extra-deps {com.cognitect/test-runner
-                        {:git/url "https://github.com/cognitect-labs/test-runner"
-                         :sha     "76568540e7f40268ad2b646110f237a60295fa3c"}}
-           :main-opts  ["-m" "cognitect.test-runner" "-d" "test"]}
-  :dev    {:extra-paths ["dev" "target"]
-           :extra-deps  {figwheel-sidecar {:mvn/version "0.5.12"}
-                         rum              {:mvn/version "0.10.8"}}}}}
+ {:clj  {:extra-deps {;; Clojure(Script) is "provided"
+                      org.clojure/clojure       {:mvn/version "1.10.0"}
+                      org.clojure/clojurescript {:mvn/version "1.10.520"}}}
+  :test {:extra-paths ["test" "target"]
+         :extra-deps  {org.clojure/test.check {:mvn/version "RELEASE"}}}
+  :dev  {:extra-paths ["dev" "target"]
+         :extra-deps  {figwheel-sidecar {:mvn/version "0.5.12"}
+                       rum              {:mvn/version "0.10.8"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,20 @@
+{:paths ["src"]
+
+ :deps {org.clojure/core.async {:mvn/version "0.3.443"}
+        com.cerner/clara-rules {:mvn/version "0.15.1" :exclusions [prismatic/schema]}
+        prismatic/schema       {:mvn/version "1.1.6"}
+        org.clojure/core.match {:mvn/version "0.3.0-alpha4"}}
+
+ :aliases
+ {:clj    {:extra-deps {;; Acts like "provided" :scope from lein
+                        org.clojure/clojure       {:mvn/version "1.10.0"}
+                        org.clojure/clojurescript {:mvn/version "1.9.671"}}}
+  :test   {:extra-paths ["test"]
+           :extra-deps  {org.clojure/test.check {:mvn/version "RELEASE"}}}
+  :runner {:extra-deps {com.cognitect/test-runner
+                        {:git/url "https://github.com/cognitect-labs/test-runner"
+                         :sha     "76568540e7f40268ad2b646110f237a60295fa3c"}}
+           :main-opts  ["-m" "cognitect.test-runner" "-d" "test"]}
+  :dev    {:extra-paths ["dev" "target"]
+           :extra-deps  {figwheel-sidecar {:mvn/version "0.5.12"}
+                         rum              {:mvn/version "0.10.8"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,10 @@
 (defproject org.arachne-framework/factui "1.1.0-SNAPSHOT"
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17" :scope "provided"]
-                 [org.clojure/clojurescript "1.9.671" :scope "provided"]
-                 [org.clojure/core.async "0.3.443"]
-                 [com.cerner/clara-rules "0.15.1" :exclusions [prismatic/schema]]
-                 [prismatic/schema "1.1.6"]
-                 [org.clojure/core.match "0.3.0-alpha4"]]
-  :source-paths ["dev" "src"]
+
+  ;; tools.deps
+  :plugins [[lein-tools-deps "0.4.5"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:install :user :project]}
+
   :profiles {:test {:plugins [[lein-shell "0.4.0" :exclusions [org.clojure/clojure]]
                               [lein-cljsbuild "1.1.6" :exclusions [org.clojure/clojure]]]
                     :cljsbuild {:builds [{:id "dev-figwheel"
@@ -61,10 +60,5 @@
                                        ["shell" "phantomjs" "target/test-bench.js"]]
                               }}
              :dev {:plugins [[lein-figwheel "0.5.12" :exclusions [org.clojure/clojurescript]]]
-                   :dependencies [[figwheel-sidecar "0.5.12"]
-                                  [rum "0.10.8"]]
-                   :source-paths ["dev" "test"]
-                   :resource-paths ["target"]
                    :clean-targets ^{:protect false} ["target" :target-path]
-
                    :figwheel {:open-file-command "emacsclient"}}})

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,10 @@
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
   :lein-tools-deps/config {:config-files [:install :user :project]}
 
-  :profiles {:test {:plugins [[lein-shell "0.4.0" :exclusions [org.clojure/clojure]]
+  :profiles {:test {:lein-tools-deps/config {:aliases [:clj :test]}
+                    :plugins [[lein-shell "0.4.0" :exclusions [org.clojure/clojure]]
                               [lein-cljsbuild "1.1.6" :exclusions [org.clojure/clojure]]]
+                    :clean-targets ^{:protect false} ["target" :target-path]
                     :cljsbuild {:builds [{:id "dev-figwheel"
                                           :source-paths ["src" "dev"]
                                           :figwheel {:on-jsload "factui.rum/refresh"}
@@ -59,6 +61,7 @@
                                        ["cljsbuild" "once" "test-bench"]
                                        ["shell" "phantomjs" "target/test-bench.js"]]
                               }}
-             :dev {:plugins [[lein-figwheel "0.5.12" :exclusions [org.clojure/clojurescript]]]
+             :dev {:lein-tools-deps/config {:aliases [:clj :dev]}
+                   :plugins [[lein-figwheel "0.5.12" :exclusions [org.clojure/clojurescript]]]
                    :clean-targets ^{:protect false} ["target" :target-path]
                    :figwheel {:open-file-command "emacsclient"}}})

--- a/src/factui/rum.cljs
+++ b/src/factui/rum.cljs
@@ -5,7 +5,7 @@
             [factui.impl.store :as store])
   (:require-macros [cljs.core.async.macros :refer [go-loop]]))
 
-(def ^:private *rebuild-on-refresh* (atom true))
+(def ^:private rebuild-on-refresh (atom true))
 
 (defn set-rebuild-on-refresh
   "Sets whether the session be should be entirely rebuilt on a new rulebase,
@@ -18,7 +18,7 @@
    However, this operation may be expensive with very large sessions. If
    refreshing takes too long, you may wish to disable this."
   [rebuild?]
-  (reset! *rebuild-on-refresh* rebuild?))
+  (reset! rebuild-on-refresh rebuild?))
 
 (defn- query-args
   "Given a Rum state and a query, return a vectory of FactUI query args, based
@@ -144,7 +144,7 @@
     (add-watch version :version-watch
       (fn [_ _ _ version]
         (let [old-session @@app-state-holder
-              new-session (if @*rebuild-on-refresh*
+              new-session (if @rebuild-on-refresh
                             (f/rebuild-session @rulebase old-session schema)
                             old-session)]
           (reset! app-state-holder (atom new-session))


### PR DESCRIPTION
This PR makes use of the [lein-tools-deps][1] plugin in order to allow depending on this project easily using tools.deps (deps.edn). Dependencies are now being declared from the `deps.edn` file, while `project.clj` remains the central location for building and testing. All tests are passing, and Figwheel development is left intact. This change aims to be fully transparent to current developers, meaning that they shouldn't need to change anything about their workflow.

Obviously if this were to be merged we would update the readme with the proper git SHA, but for now the current instructions serve as a placeholder.

(Referencing #8 for posterity)

[1]: https://github.com/RickMoynihan/lein-tools-deps